### PR TITLE
Subclass `"data.frame"` rather than superclassing it

### DIFF
--- a/R/BSseq_util.R
+++ b/R/BSseq_util.R
@@ -316,7 +316,7 @@ dispersion.shrinkage.BSseq <- function(X, N, prior, estprob, ncores) {
             exp(shrk.one$minimum)
         }
         shrk.phi2 <- try(mclapply(1:nrow(X2), foo, mc.cores=ncores))
-        if(class(shrk.phi2) == "try-error") {
+        if(inherits(shrk.phi2, "try-error")) {
             stop(paste("Shrinkage estimator in parallel computing encountered errors.",
                        "Please switch to single core.\n"))
         } else {

--- a/R/DML.R
+++ b/R/DML.R
@@ -54,7 +54,7 @@ DMLtest <- function(BSobj, group1, group2, equal.disp=FALSE, smoothing=FALSE,
         dmls <- DMLtest.Smooth(BS1, BS2, equal.disp, smoothing.span, ncores)
     }
 
-    class(dmls)[2] = "DMLtest"
+    class(dmls) = c("DMLtest", class(dmls))
     invisible(dmls)
 }
 
@@ -354,7 +354,7 @@ compute.var.Smooth.old <- function(estprob1, n1, phi1, smoothing.span, allchr, a
 ################################################
 callDML <- function(DMLresult, delta=0.1, p.threshold=1e-5) {
 
-    if(class(DMLresult)[2] == "DMLtest.multiFactor" & delta>0) {
+    if(inherits(DMLresult, "DMLtest.multiFactor") & delta>0) {
         warning("'delta' cannot be specified for multiple-factor test results. Set delta=0 and proceed ...\n")
         delta = 0
     }

--- a/R/DML.multiFactor.R
+++ b/R/DML.multiFactor.R
@@ -161,7 +161,7 @@ DMLtest.multiFactor <- function(DMLfit, coef=2, term, Contrast) {
 
     }
 
-    class(res)[2] = "DMLtest.multiFactor"
+    class(res) = c("DMLtest.multiFactor", class(res))
     invisible(res)
 
 }

--- a/R/DMR.R
+++ b/R/DMR.R
@@ -12,7 +12,7 @@ callDMR <- function(DMLresult, delta=0, p.threshold=1e-5,
         DMLresult = DMLresult[ix.keep,]
 
     flag.multifactor = FALSE
-    if(class(DMLresult)[2] == "DMLtest.multiFactor")
+    if(inherits(DMLresult, "DMLtest.multiFactor"))
         flag.multifactor = TRUE
 
     if(dis.merge > minlen)


### PR DESCRIPTION
We got a report in https://github.com/r-lib/vctrs/issues/1758 that the `DMLtest` data frame class isn't compatible with dplyr operations. It looks like you _superclass_ data frame with the class being `c("data.frame", "DMLtest")`. We don't allow this in vctrs/dplyr, which needs you to _subclass_ a data frame for it to be compatible with dplyr, like `c("DMLtest", "data.frame")`. I'm hoping that difference isn't very important for you.

I've also fixed some usage of `class() ==` in `if` statements, which is considered bad practice over using `inherits()` (R CMD check will warn about this).

@llrs hopefully this fixes your issue.

